### PR TITLE
Add GitHub Action to build each pushed commit for windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on: [push]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  windows:
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test
+        run: cargo test --release
+      - name: Build
+        run: cargo build --release
+      - name: Upload portable executable
+        uses: actions/upload-artifact@v2
+        with:
+          name: release
+          path: |
+            target/release/*.exe
+


### PR DESCRIPTION
See an example: https://github.com/colemickens/gpg-bridge/actions/runs/476628465

This will build each pushed commit and then attach a zip file containing `gpg-bridge.exe` in the zip file.

This will resolve #1 as well!